### PR TITLE
fix(workaround): Creating a new machine per iteration

### DIFF
--- a/dualnet/meta.go
+++ b/dualnet/meta.go
@@ -13,14 +13,16 @@ import (
 )
 
 // Train is a basic trainer.
+//
+// BUG(gorgonia): One instance of the machie is created per batch; this should be fixed once the reset method is fixed. See #2 for more info.
 func Train(d *Dual, Xs, policies, values *tensor.Dense, batches, iterations int) error {
-	m := G.NewTapeMachine(d.g, G.BindDualValues(d.Model()...))
 	model := G.NodesToValueGrads(d.Model())
 	solver := G.NewVanillaSolver(G.WithLearnRate(0.1))
 	var s slicer
 	for i := 0; i < iterations; i++ {
 		// var cost float32
 		for bat := 0; bat < batches; bat++ {
+			m := G.NewTapeMachine(d.g, G.BindDualValues(d.Model()...))
 			batchStart := bat * d.Config.BatchSize
 			batchEnd := batchStart + d.Config.BatchSize
 
@@ -38,7 +40,7 @@ func Train(d *Dual, Xs, policies, values *tensor.Dense, batches, iterations int)
 			if err := solver.Step(model); err != nil {
 				return err
 			}
-			m.Reset()
+			//m.Reset()
 			tensor.ReturnTensor(Xs2)
 			tensor.ReturnTensor(π)
 			tensor.ReturnTensor(v)

--- a/dualnet/meta_test.go
+++ b/dualnet/meta_test.go
@@ -1,0 +1,73 @@
+package dual
+
+import (
+	"testing"
+
+	"gorgonia.org/tensor"
+)
+
+
+func TestTrain(t *testing.T) {
+	features := 2
+	height := 3
+	width := 3
+	actionSpace := 10
+	batchSize := 100
+	batchesZero := 0
+	batchesOne := 1
+
+	conf := DefaultConf(3, 3, 10)
+	conf.BatchSize = batchSize
+	conf.Features = features
+	conf.K = 3
+	conf.SharedLayers = 3
+	type args struct {
+		d          *Dual
+		Xs         *tensor.Dense
+		policies   *tensor.Dense
+		values     *tensor.Dense
+		batches    int
+		iterations int
+	}
+	d := &Dual{Config: conf}
+	if err := d.Init(); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"issue #2 batch one (not working)",
+			args{
+				d:          d,
+				Xs:         tensor.New(tensor.WithBacking(make([]float32, batchSize*batchesOne*features*height*width)), tensor.WithShape(batchSize*batchesOne, features, height, width)),
+				policies:   tensor.New(tensor.WithBacking(make([]float32, batchSize*batchesOne*actionSpace)), tensor.WithShape(batchSize*batchesOne, actionSpace)),
+				values:     tensor.New(tensor.WithBacking(make([]float32, batchSize*batchesOne)), tensor.WithShape(batchSize*batchesOne)),
+				batches:    batchesOne,
+				iterations: 100,
+			},
+			false,
+		},
+		{
+			"issue #2 batches zero",
+			args{
+				d:          d,
+				Xs:         tensor.New(tensor.WithBacking(make([]float32, batchSize*batchesZero*features*height*width)), tensor.WithShape(batchSize*batchesZero, features, height, width)),
+				policies:   tensor.New(tensor.WithBacking(make([]float32, batchSize*batchesZero*actionSpace)), tensor.WithShape(batchSize*batchesZero, actionSpace)),
+				values:     tensor.New(tensor.WithBacking(make([]float32, batchSize*batchesZero)), tensor.WithShape(batchSize*batchesZero)),
+				batches:    batchesZero,
+				iterations: 100,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Train(tt.args.d, tt.args.Xs, tt.args.policies, tt.args.values, tt.args.batches, tt.args.iterations); (err != nil) != tt.wantErr {
+				t.Errorf("Train() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes #4  by introducing a workaround.

The problem is related to the Reset method that may suffer from a bug.
Actually, two consecutive operations are not idempotent.

This fixes the problem by introducing a workaround: creating a `Machine` for each interaction instead of relying on a unique one.
It obviously has an impact on the performances because due to more pressure on the GC.

This should be changed back once the bug is located and fixed.
