### PR TITLE
fix: return an error if batches is null

### DIFF
--- a/agogo.go
+++ b/agogo.go
@@ -120,6 +120,9 @@ func (a *AZ) Learn(iters, episodes, nniters, arenaGames int) error {
 			ex = ex[:a.maxExamples]
 		}
 		Xs, Policies, Values, batches := a.prepareExamples(ex)
+		if batches == 0 {
+			return errors.New("batches is nil, probably too few examples regarding the batchsize")
+		}
 
 		// // create a new DualNet for B
 		// a.B.NN = dual.New(a.nnConf)


### PR DESCRIPTION
The `prepareExamples` method of `AZ` returns a number of batches.
If this number is null, the `Train` function returns a self-explanatory error and does not trigger the training of the NN.

This should fix #3 